### PR TITLE
Add defaultMode to extraSecrets comment in values.yaml

### DIFF
--- a/charts/coredns/values.yaml
+++ b/charts/coredns/values.yaml
@@ -237,8 +237,10 @@ extraVolumeMounts: []
 extraSecrets: []
 # - name: etcd-client-certs
 #   mountPath: /etc/coredns/tls/etcd
+#   defaultMode: 420
 # - name: some-fancy-secret
 #   mountPath: /etc/wherever
+#   defaultMode: 440
 
 # To support legacy deployments using CoreDNS with the "k8s-app: kube-dns" label selectors.
 # See https://github.com/coredns/helm/blob/master/charts/coredns/README.md#adopting-existing-coredns-resources


### PR DESCRIPTION
Update to values file extraSecrets docs / comments. Addresses bug: https://github.com/coredns/helm/issues/144

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->
#### Why is this pull request needed and what does it do?

#### Which issues (if any) are related?


Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#versioning).
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Changes are automatically published when merged to `main`. They are not published on branches.

<details>
  <summary>Note on DCO</summary>

  If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

